### PR TITLE
ONESHOT and TIMEOUT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,10 @@ FROM python:3.11-alpine
 WORKDIR /app
 
 COPY requirements.txt .
-COPY src ./
 
 RUN python3 -m pip install -U pip
 RUN python -m pip install -r requirements.txt
+
+COPY src ./
 
 CMD ["python3", "run.py"]

--- a/src/config.py
+++ b/src/config.py
@@ -13,9 +13,9 @@ _ONESHOT: str = os.getenv("ONESHOT", "false")
 ONESHOT: bool = True if _ONESHOT.lower() == "true" else False
 
 # https://www.python-httpx.org/advanced/#timeout-configuration
-_TIMEOUT: int = int(os.getenv("TIMEOUT", "5"))
+_REQUEST_TIMEOUT: int = int(os.getenv("REQUEST_TIMEOUT", "5"))
 # timeouts are disabled if None is used
-TIMEOUT: int = None if _TIMEOUT == -1 else _TIMEOUT
+REQUEST_TIMEOUT: int = None if _REQUEST_TIMEOUT == -1 else _REQUEST_TIMEOUT
 
 BASE_PATH: Path = Path(".")
 

--- a/src/config.py
+++ b/src/config.py
@@ -12,6 +12,11 @@ import httpx
 _ONESHOT: str = os.getenv("ONESHOT", "false")
 ONESHOT: bool = True if _ONESHOT.lower() == "true" else False
 
+# https://www.python-httpx.org/advanced/#timeout-configuration
+_TIMEOUT: int = int(os.getenv("TIMEOUT", "5"))
+# timeouts are disabled if None is used
+TIMEOUT: int = None if _TIMEOUT == -1 else _TIMEOUT
+
 BASE_PATH: Path = Path(".")
 
 # common config

--- a/src/config.py
+++ b/src/config.py
@@ -7,6 +7,11 @@ from pathlib import Path
 
 import httpx
 
+# only run once
+# allows wg-ephemeral to be used as a cronjob
+_ONESHOT: str = os.getenv("ONESHOT", "false")
+ONESHOT: bool = True if _ONESHOT.lower() == "true" else False
+
 BASE_PATH: Path = Path(".")
 
 # common config
@@ -40,7 +45,7 @@ COOKIES.set("ref", "https://windscribe.com/")
 
 
 # fmt: off
-# some qbitconfig
+# some qbit config
 QBIT_USERNAME: str = os.getenv("QBIT_USERNAME", "default123!!")
 QBIT_PASSWORD: str = os.getenv("QBIT_PASSWORD", "default123!!")
 QBIT_HOST: str     = os.getenv("QBIT_HOST", "127.0.0.1")
@@ -58,7 +63,7 @@ _QBIT_PRIVATE_TRACKER: str = os.getenv("QBIT_PRIVATE_TRACKER", "false")
 QBIT_PRIVATE_TRACKER: bool = True if _QBIT_PRIVATE_TRACKER.lower() == "true" else False
 
 
-# wait befor setting the ephemeral ports
+# wait before setting the ephemeral ports
 try:
     DAYS: int = int(os.getenv("DAYS", 6))
 except TypeError:

--- a/src/run.py
+++ b/src/run.py
@@ -69,7 +69,8 @@ if __name__ == "__main__":
     schedule.every(5).minutes.do(monitor)
     schedule.run_all()
 
-    logger.info(f"Schedule is setup to run every {config.DAYS} day at {config.TIME}")
-    while True:
-        schedule.run_pending()
-        time.sleep(1)
+    if not config.ONESHOT:
+        logger.info(f"Schedule is setup to run every {config.DAYS} day at {config.TIME}")
+        while True:
+            schedule.run_pending()
+            time.sleep(1)

--- a/src/ws.py
+++ b/src/ws.py
@@ -38,7 +38,7 @@ class Windscribe:
             # ruff: noqa: E501
             "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36",
         }
-        self.client = httpx.Client(headers=headers, cookies=config.COOKIES, timeout=config.TIMEOUT)
+        self.client = httpx.Client(headers=headers, cookies=config.COOKIES, timeout=config.REQUEST_TIMEOUT)
 
         # we will populate this later in the login call
         self.csrf: Csrf = self._get_csrf()

--- a/src/ws.py
+++ b/src/ws.py
@@ -38,7 +38,7 @@ class Windscribe:
             # ruff: noqa: E501
             "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36",
         }
-        self.client = httpx.Client(headers=headers, cookies=config.COOKIES)
+        self.client = httpx.Client(headers=headers, cookies=config.COOKIES, timeout=config.TIMEOUT)
 
         # we will populate this later in the login call
         self.csrf: Csrf = self._get_csrf()


### PR DESCRIPTION
Hi, this patch adds the ONESHOT and TIMEOUT configuration options

- ONESHOT runs main once and quits. This lets you use ws-ephemeral as a cronjob.
- TIMEOUT configures the request timeout used when connecting to windscribe. The default 5s timeout sometimes gives me errors so it's convenient to have it adjustable

I've also reordered the Dockerfile so that changes to the source code don't cause a reinstall of all python dependencies.

Please let me know what you think.