### PR TITLE
feat: Implement Port Manager for Handling Port Expiration and State Management

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -35,6 +35,7 @@ WS_USERNAME: str = os.getenv("WS_USERNAME", "")
 WS_PASSWORD: str = os.getenv("WS_PASSWORD", "")
 WS_TOTP: str | None = os.getenv("WS_TOTP", None)
 WS_COOKIE = Path(os.getenv("WS_COOKIE_PATH", ".")) / "cookie.pkl"
+WS_ENVFILE = Path(os.getenv("WS_COOKIE_PATH", ".")) / "port.env"
 
 if not all([WS_USERNAME, WS_PASSWORD]):
     print("ENV: WS_USERNAME and WS_PASSWORD need to be set")

--- a/src/run.py
+++ b/src/run.py
@@ -4,6 +4,7 @@ Module that run the setup for windscrib's ephemeral port
 
 import logging
 import time
+import datetime
 
 import schedule
 
@@ -24,20 +25,22 @@ def main() -> None:
     """Main function responsible for setting up ws and qbit.
 
     Steps:
+    - check if the port is still valid
+    - login to ws (if needed)
+    - setup new matching ports (if needed)
     - check if the hearbeat was okay
-    - login to ws
-    - setup new matching ports
     - setup qbit
     """
     try:
         port_manager = PortManager.deserialize_from_env(config.WS_ENVFILE)
-        if not port_manager.is_expired():
-            logger.debug("Port is still valid, skipping update...")
+        if port_manager and not port_manager.is_expired():
+            expiration_time = port_manager.expiration_time.strftime('%Y-%m-%d %H:%M:%S')
+            logger.debug("Port %d is still valid until %s, skipping update...", port_manager.port, expiration_time)
             return
         else:
             logger.info("Port expired (or about to expire), reallocating a new port...")
     except Exception as e:
-        logger.warning(f"PortManager deserialization failed or port expired: {e}")
+        logger.warning(f"PortManager deserialization failed: {e}")
         logger.info("Reallocating a new port...")
 
     logger.info("Running automation...")

--- a/src/run.py
+++ b/src/run.py
@@ -12,7 +12,7 @@ from lib.qbit import QbitManager
 from logger import setup_logging
 from monitor import HEARTBEAT, monitor
 from util import catch_exceptions
-from ws import Windscribe
+from ws import Windscribe, PortManager
 
 setup_logging()
 
@@ -29,6 +29,24 @@ def main() -> None:
     - setup new matching ports
     - setup qbit
     """
+    try:
+        port_manager = PortManager.deserialize_from_env(config.WS_ENVFILE)
+        if not port_manager.is_expired():
+            logger.debug("Port is still valid, skipping update...")
+            return
+        else:
+            logger.info("Port expired (or about to expire), reallocating a new port...")
+    except Exception as e:
+        logger.warning(f"PortManager deserialization failed or port expired: {e}")
+        logger.info("Reallocating a new port...")
+
+    logger.info("Running automation...")
+    with Windscribe(
+        username=config.WS_USERNAME, password=config.WS_PASSWORD, totp=config.WS_TOTP
+    ) as ws:
+        port_manager = ws.setup()
+        port_manager.serialize_to_env(config.WS_ENVFILE)
+
     if not HEARTBEAT:
         msg = (
             "From hearbeat check, "
@@ -37,12 +55,6 @@ def main() -> None:
         )
         logger.error(msg)
         return
-
-    logger.info("Running automation...")
-    with Windscribe(
-        username=config.WS_USERNAME, password=config.WS_PASSWORD, totp=config.WS_TOTP
-    ) as ws:
-        port = ws.setup()
 
     if not config.QBIT_FOUND:
         logger.warning(
@@ -60,7 +72,7 @@ def main() -> None:
     except Exception:
         logger.error("not able to work with qbit")
         raise
-    qbit.set_listen_port(port)
+    qbit.set_listen_port(port_manager.get_port())
 
     if config.QBIT_PRIVATE_TRACKER:
         qbit.setup_private_tracker()
@@ -68,7 +80,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    schedule.every(config.DAYS).days.at(config.TIME).do(main)
+    schedule.every(5).minutes.do(main)
     schedule.every(5).minutes.do(monitor)
     schedule.run_all()
 

--- a/src/ws/__init__.py
+++ b/src/ws/__init__.py
@@ -1,3 +1,3 @@
-from .ws import Windscribe
+from .ws import Windscribe, PortManager
 
-__all__ = ["Windscribe"]
+__all__ = ["Windscribe", "PortManager"]

--- a/src/ws/portmanager.py
+++ b/src/ws/portmanager.py
@@ -1,0 +1,51 @@
+import random
+import time
+from datetime import datetime, timedelta
+
+class PortManager:
+    def __init__(self, port: int, timestamp: int):
+        self.port = port
+        self.timestamp = timestamp
+        self.expiration_time = self._calculate_expiration_time()
+
+    def _calculate_expiration_time(self) -> datetime:
+        """Calculate a random expiration time between 6 to 7 days after the timestamp."""
+        min_days = 6
+        max_days = 7
+        random_minutes = random.randint(min_days * 24 * 60, max_days * 24 * 60)
+        return datetime.fromtimestamp(self.timestamp) + timedelta(minutes=random_minutes)
+
+    def get_port(self) -> int:
+        """Return the port."""
+        return self.port
+
+    def is_expired(self) -> bool:
+        """Check if the port is expired."""
+        return datetime.now() > self.expiration_time
+
+    def serialize_to_env(self, file_path: str) -> None:
+        """Serialize the port and timestamp to a .env file."""
+        try:
+            with open(file_path, 'w') as file:
+                file.write(f"WS_LAST_PORT={self.port}\n")
+                file.write(f"WS_LAST_TIMESTAMP={self.timestamp}\n")
+                file.write(f"WS_EXPIRATION={int(self.expiration_time.timestamp())}\n")
+        except IOError as e:
+            print(f"Error writing to file {file_path}: {e}")
+
+    @classmethod
+    def deserialize_from_env(cls, file_path: str) -> "PortManager":
+        """Deserialize the port and timestamp from a .env file."""
+        try:
+            with open(file_path, 'r') as file:
+                data = file.readlines()
+                port = int(data[0].strip().split('=')[1])
+                timestamp = int(data[1].strip().split('=')[1])
+                expiration_time = int(data[2].strip().split('=')[1])
+            
+            instance = cls(port, timestamp)
+            instance.expiration_time = datetime.fromtimestamp(expiration_time)
+            return instance
+        except (IOError, IndexError, ValueError) as e:
+            print(f"Error reading from file {file_path}: {e}")
+            return None

--- a/src/ws/ws.py
+++ b/src/ws/ws.py
@@ -14,6 +14,8 @@ from typing import TypedDict, Union
 import httpx
 import pyotp
 
+import datetime
+
 import config
 from lib.decorators import login_required
 
@@ -166,6 +168,12 @@ class Windscribe:
         
         if external != internal:
             raise ValueError("Port setup done but matching port not found.")
+
+        # Log the new port reservation at info level
+        start_time = datetime.datetime.fromtimestamp(start_ts).strftime('%Y-%m-%d %H:%M:%S')
+        expiration_time = (datetime.datetime.fromtimestamp(start_ts) + datetime.timedelta(hours=1)).strftime('%Y-%m-%d %H:%M:%S')
+        self.logger.info("New port reserved: %d, Start time: %s, Expiration time: %s", internal, start_time, expiration_time)
+
 
         return PortManager(internal, start_ts)
 

--- a/src/ws/ws.py
+++ b/src/ws/ws.py
@@ -18,7 +18,7 @@ import config
 from lib.decorators import login_required
 
 from .cookie import default_cookie, load_cookie, save_cookie
-
+from .portmanager import PortManager
 
 class Csrf(TypedDict):
     """CSRF type dict"""
@@ -142,7 +142,7 @@ class Windscribe:
         return res
 
     @login_required
-    def set_matching_port(self) -> int:
+    def set_matching_port(self) -> PortManager:
         """
         setup matching ephemeral port on WS
         """
@@ -162,13 +162,14 @@ class Windscribe:
         # lets make sure we actually had matching port
         external: int = res["epf"]["ext"]
         internal: int = res["epf"]["int"]
-
+        start_ts: int = res["epf"]["start_ts"]
+        
         if external != internal:
             raise ValueError("Port setup done but matching port not found.")
 
-        return internal
+        return PortManager(internal, start_ts)
 
-    def setup(self) -> int:
+    def setup(self) -> PortManager:
         """perform ephemeral port setup here"""
         # after login we need to update the csrf token agian,
         # windscribe puts new csrf token in the javascript


### PR DESCRIPTION
This pull request introduces a Port Manager to handle port expiration and maintain state between runs. The key changes include:

- Implemented a port lifetime manager to avoid renewing ports unnecessarily by maintaining state between runs.
- Added functions to calculate expiration time, check if a port is expired, and serialize/deserialize port data to/from a `.env` file.
- Integrated the `PortManager` into the main function to handle port expiration and external monitoring, with early exit if the port is still valid.
- Enhanced logging for port events, including expiration times, reservation, and reallocation.

This is my first time coding in Python so I might have goofed in some places but I'm running right now and it seems to work well for me.

Please note that this implementation was created to meet my specific needs and may not align with the direction you're looking for. If this approach is not suitable, feel free to close the pull request. Note that I am open to feedback and willing to make any changes to better fit the direction. I thought I'd still push a PR in case you'd want part of that code